### PR TITLE
GET creative working for production

### DIFF
--- a/src/store/modules/creatives.js
+++ b/src/store/modules/creatives.js
@@ -31,7 +31,7 @@ const getters = {
 
 const actions = {
     async fetchCreatives({ commit }) {
-        const URL = "/creatives";
+        const URL = process.env.VUE_APP_CELTRA_URL + "/creatives";
 
         var username = process.env.VUE_APP_CELTRA_APP_ID;
         var password = process.env.VUE_APP_CELTRA_SECRET_KEY;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    devServer: {
-        proxy: process.env.VUE_APP_CELTRA_URL,
-        compress: true,
-        disableHostCheck: true,
-    }
-}


### PR DESCRIPTION
This fixes problem with production GET request but only with a small change on backend side. Responses from API should have a proper Allow-origin-header property, otherwise request is blocked by CORS on client side.
 *External API endpoints should be configured with proper headers*